### PR TITLE
Scan new directories, allow to filter for interesting events

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,12 @@
 # Change file for File::Hotfolder
 
-{{$NEXT}}
-    - support forking (issue #6)
- 
+0.06
+    - bugfix for new directory race
+
+0.05
+    - initial support for forking (issue #6)
+    - added event_mask param
+
 0.04  2015-03-26 11:53:22 CET
     - improved filter and new option: filter_dir (issue #7)
     - extended logging

--- a/META.json
+++ b/META.json
@@ -57,7 +57,7 @@
          "web" : "https://github.com/nichtich/File-Hotfolder"
       }
    },
-   "version" : "0.04",
+   "version" : "0.06",
    "x_contributors" : [
       "Jakob Voss <voss@gbv.de>"
    ]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ File::Hotfolder - recursive watch directory for new or modified files
             my $path = shift;
             ...
         },
+        fork     => 0,                  # fork callback
         delete   => 1,                  # delete each file if callback returns true
         filter   => qr/\.json$/,        # only watch selected files
         print    => WATCH_DIR           # show which directories are watched
@@ -26,7 +27,8 @@ File::Hotfolder - recursive watch directory for new or modified files
         catch    => sub {               # catch callback errors
             my ($path, $error) = @_;
             ...
-        }
+        },
+        event_mask => IN_CLOSE          # filter event only to those of interest
     )->loop;
 
     # function interface
@@ -42,6 +44,9 @@ File::Hotfolder - recursive watch directory for new or modified files
         print   => DELETE_FILE | KEEP_FILE
     );
     
+    # wait for events with AnyEvent
+    File::HotFolder->new( ... )->anyevent;
+    AnyEvent->condvar->recv;
 
 # DESCRIPTION
 
@@ -72,6 +77,14 @@ be watched as well.
     default). A `DELETE_FILE` will be logged after deletion or a `KEEP_FILE`
     event otherwise.
 
+- event\_mask
+
+    React only to those event satisfying the mask. Can be any mask built of the
+    following Linux::Inotify2 event flags: `IN_CREATE`, `IN_CLOSE_WRITE`,
+    `IN_MOVE`, `IN_DELETE`, `IN_DELETE_SELF`, `IN_MOVE_SELF`.
+
+    Defaults to `IN_CLOSE_WRITE` | `IN_MOVED_TO`.
+
 - fullname
 
     Return absolute path names. By default pathes are relative to the base
@@ -88,14 +101,20 @@ be watched as well.
     Filter directory names with regular expression before watching. Set to ignore
     hidden directories (starting with a dot) by default. Use `0` to disable.
 
+- fork
+
+    Execute callback in a child process by forking if possible.  Logging also takes
+    place in the child process.
+
 - print
 
-    Which events to log. Unless parameter `logger` is specified, events are
-    printed to STDOUT or STDERR. Possible event types are exported as constants
-    `WATCH_DIR`, `UNWATCH_DIR`, `FOUND_FILE`, `DELETE_FILE`, `KEEP_FILE`,
-    `CATCH_ERROR`, and `WATCH_ERROR`. The constant `HOTFOLDER_ERROR` combines
-    `CATCH_ERROR` and `WATCH_ERROR` and the constant `HOTFOLDER_ALL` combines
-    all event types.
+    Log events to STDOUT and STDERR unless an explicit `logger` is specified.
+
+    This parameter expects a value with event types.  Possible event types are
+    exported as constants `WATCH_DIR`, `UNWATCH_DIR`, `FOUND_FILE`,
+    `DELETE_FILE`, `KEEP_FILE`, `CATCH_ERROR`, and `WATCH_ERROR`. The constant
+    `HOTFOLDER_ERROR` combines `CATCH_ERROR` and `WATCH_ERROR` and the constant
+    `HOTFOLDER_ALL` combines all event types.
 
 - logger
 
@@ -144,9 +163,8 @@ may use another notify module ([Win32::ChangeNotify](https://metacpan.org/pod/Wi
 
 # SEE ALSO
 
-[File::ChangeNotify](https://metacpan.org/pod/File::ChangeNotify), [Filesys::Notify::Simple](https://metacpan.org/pod/Filesys::Notify::Simple)
-
-[AnyEvent](https://metacpan.org/pod/AnyEvent)
+- [File::ChangeNotify](https://metacpan.org/pod/File::ChangeNotify), [Filesys::Notify::Simple](https://metacpan.org/pod/Filesys::Notify::Simple)
+- [AnyEvent](https://metacpan.org/pod/AnyEvent)
 
 # COPYRIGHT AND LICENSE
 

--- a/lib/File/Hotfolder.pm
+++ b/lib/File/Hotfolder.pm
@@ -1,9 +1,8 @@
 package File::Hotfolder;
-use strict;
 use warnings;
 use v5.10;
 
-our $VERSION = '0.04';
+our $VERSION = '0.05';
 
 use Carp;
 use File::Find;
@@ -60,6 +59,7 @@ sub new {
         scan       => $args{scan},
         catch      => _build_catch($args{catch}),
         logger     => _build_logger($args{logger}),
+        event_mask => ($args{event_mask} || ( IN_CLOSE_WRITE | IN_MOVED_TO )),
     }, $class;
 
     $self->watch_recursive( $path );
@@ -128,7 +128,7 @@ sub _watch_directory {
                     $self->log( UNWATCH_DIR, $path );
                     $e->w->cancel;
                 }
-            } elsif ( $e->IN_CLOSE_WRITE || $e->IN_MOVED_TO ) {
+            } elsif ( $e->mask & $self->{event_mask} ) {
                 $self->_callback($path);
             }
 
@@ -195,8 +195,8 @@ our %LOGS = (
     FOUND_FILE  , "found %s",
     KEEP_FILE   , "keep %s",
     DELETE_FILE , "delete %s",
-    CATCH_ERROR , "error %s: %s",
-    WATCH_ERROR , "failed %s: %s",
+    CATCH_ERROR , "error %s",
+    WATCH_ERROR , "failed %s",
 );
 
 sub _build_logger {
@@ -229,7 +229,7 @@ sub log {
         $self->{logger}->( 
             event   => $event,
             path    => $path,
-            message => sprintf($LOGS{$event}, $path, $event),
+            message => sprintf($LOGS{$event}, $path),
         );
     }
 }
@@ -270,7 +270,8 @@ File::Hotfolder - recursive watch directory for new or modified files
         catch    => sub {               # catch callback errors
             my ($path, $error) = @_;
             ...
-        }
+        },
+        event_mask => IN_CLOSE          # filter event only to those of interest
     )->loop;
 
     # function interface
@@ -320,6 +321,14 @@ before executing the callback.
 Delete the modified file if a callback returned a true value (disabled by
 default). A C<DELETE_FILE> will be logged after deletion or a C<KEEP_FILE>
 event otherwise.
+
+=item event_mask
+
+React only to those event satisfying the mask. Can be any mask built of the
+following Linux::Inotify2 event flags: C<IN_CREATE>, C<IN_CLOSE_WRITE>,
+C<IN_MOVE>, C<IN_DELETE>, C<IN_DELETE_SELF>, C<IN_MOVE_SELF>.
+
+Defaults to C<IN_CLOSE_WRITE> | C<IN_MOVED_TO>.
 
 =item fullname
 

--- a/lib/File/Hotfolder.pm
+++ b/lib/File/Hotfolder.pm
@@ -2,7 +2,7 @@ package File::Hotfolder;
 use warnings;
 use v5.10;
 
-our $VERSION = '0.05';
+our $VERSION = '0.06';
 
 use Carp;
 use File::Find;
@@ -62,7 +62,7 @@ sub new {
         event_mask => ($args{event_mask} || ( IN_CLOSE_WRITE | IN_MOVED_TO )),
     }, $class;
 
-    $self->watch_recursive( $path );
+    $self->watch_recursive( $path, 1 );
 
     $self;
 }
@@ -81,14 +81,14 @@ sub _build_filter {
 }
 
 sub watch_recursive {
-    my ($self, $path) = @_;
+    my ($self, $path, $is_root) = @_;
 
     my $args = {
         no_chdir => 1, 
         wanted => sub {
             if (-d $_) {
                 $self->_watch_directory($_);
-            } elsif( $self->{scan} ) {
+            } elsif( !$is_root || $self->{scan} ) {
                 # TODO: check if not open or modified (lsof or fuser)
                 $self->_callback($_);
             }


### PR DESCRIPTION
* Fixes the bug with new directories being moved under the watched tree already with some files.
* Allows to filter events that should be reacted to.
** This hardcodes dependency on Linux::Inotify2 but since no one has had the need to port this library to anything else I don't consider a pressing issue.